### PR TITLE
Circleci project setup

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "npm run clean && npm run protobuild && tsc && cp src/proto_compiled.js build/src/proto_compiled.js",
     "clean": "(rm -r ./build || true)",
-    "test": "mocha && npm run bench",
+    "test": "mocha",
     "bench": "node build/test/benchmark/benchmark.js",
     "tsc": "tsc",
     "tscw": "tsc --watch",

--- a/client/test/benchmark/benchmark.ts
+++ b/client/test/benchmark/benchmark.ts
@@ -1,3 +1,3 @@
-console.log("Benchmark v2");
+console.log("Benchmark");
 
 // TODO


### PR DESCRIPTION
Make CircleCI use `npm ci` instead of `npm install`, per discussion in https://github.com/composablesys/compoventuals/pull/8