### PR TITLE
Fix inferred mixin constructor signature

### DIFF
--- a/client/src/crdts/mixins/AddAllAbilitiesViaChildren.ts
+++ b/client/src/crdts/mixins/AddAllAbilitiesViaChildren.ts
@@ -10,9 +10,9 @@ import {
   isResettable,
   isStrongResettable,
 } from "./abilities";
-import { Constructor, Mixin } from "./mixin";
+import { Constructor, CrdtMixin } from "./mixin";
 
-export const AddAllAbilitiesViaChildren: Mixin<
+export const AddAllAbilitiesViaChildren: CrdtMixin<
   Crdt & HardResettable,
   AllAble
 > = <Input extends Constructor<Crdt & HardResettable>>(Base: Input) => {

--- a/client/src/crdts/mixins/AddAllAbilitiesViaHistory.ts
+++ b/client/src/crdts/mixins/AddAllAbilitiesViaHistory.ts
@@ -7,14 +7,14 @@ import {
 } from "../resettable";
 import { SemidirectState } from "../semidirect";
 import { AbilityFlag, AllAble, InterfaceOf } from "./abilities";
-import { Constructor, MixinOpt1 } from "./mixin";
+import { Constructor, CrdtMixinWithOptions } from "./mixin";
 import { AddStrongResettable } from "./StrongResettable";
 
 export interface AllAbleWithResetState extends AllAble {
   getResetState(): SemidirectState;
 }
 
-export const AddAllAbilitiesViaHistory: MixinOpt1<
+export const AddAllAbilitiesViaHistory: CrdtMixinWithOptions<
   Crdt & HardResettable,
   AllAbleWithResetState,
   boolean

--- a/client/src/crdts/mixins/StrongResettable.ts
+++ b/client/src/crdts/mixins/StrongResettable.ts
@@ -1,6 +1,6 @@
 import { Crdt, CrdtRuntime } from "../crdt_core";
 import { HardResettable, StrongResetWrapperCrdt } from "../resettable";
-import { Constructor, Mixin } from "./mixin";
+import { Constructor, CrdtConstructor, CrdtMixin } from "./mixin";
 
 export interface StrongResettable {
   /**
@@ -19,7 +19,7 @@ export interface StrongResettable {
   strongReset(): void;
 }
 
-export const AddStrongResettable: Mixin<
+export const AddStrongResettable: CrdtMixin<
   Crdt & HardResettable,
   StrongResettable
 > = <Input extends Constructor<Crdt & HardResettable>>(Base: Input) =>

--- a/client/src/crdts/mixins/mixin.ts
+++ b/client/src/crdts/mixins/mixin.ts
@@ -1,21 +1,64 @@
-export type Constructor<T = {}> = new (...args: any[]) => T;
+import { Crdt, CrdtRuntime } from "../crdt_core";
+
+export type Constructor<T> = new (...args: any[]) => T;
 
 /**
+ * A `CrdtConstructor` is a constructor function that takes as its first two
+ * parameters the two parameters that all CRDTs must take: a `parent` and an id.
+ * No constraint is imposed on the remaining parameters. This constructor
+ * function must return a {@link Crdt} instance of type `T`.
+ *
+ * @typeParam T - Type of the returned {@link Crdt} instance
+ */
+export type CrdtConstructor<T extends Crdt> = new (
+  parent: Crdt | CrdtRuntime,
+  id: string,
+  ...otherArgs: any[]
+) => T;
+
+/**
+ * A mixin meant to be applied to a {@link Crdt}.
+ *
+ * Mixins are functions that take a class constructor of type `Input`, which
+ * must be a subtype of `Required`, and generate a constructor for a class that
+ * mixes the interface of `Input` with its own interface `Self`.
+ *
+ * Note that `CrdtMixin` uses a {@link CrdtConstructor}, but actual mixins typed
+ * with `CrdtMixin` use a regular {@link Constructor}. The reason for this is
+ * that TypeScript requires mixin constructors to have a single rest parameter
+ * with type `any[]` (see error ts(2545)). The implementation of a mixin can
+ * therefore not respect the contract of {@link CrdtConstructor}. However, we
+ * can signal the contract to the outside world by using {@link CrdtConstructor}
+ * in the type annotation. TypeScript is able to unify the type signature of
+ * mixins with the type signature of the `CrdtMixin`. This gives us the
+ * flexibility to type our code *and* show a slightly different contract to the
+ * outside wold.
+ *
+ * This is probably unsound, but it's quite convenient. Note that soundness
+ * {@link https://github.com/Microsoft/TypeScript/wiki/TypeScript-Design-Goals |
+ * is a non-goal of TypeScript}.
+ *
+ * @see {@link https://www.typescriptlang.org/docs/handbook/mixins.html}
+ * @see {@link https://justinfagnani.com/2015/12/21/real-mixins-with-javascript-classes/}
+ *
  * @typeParam Required - The minimal interface into which this mixin can be
- * merged.
+ * merged. Must be at least a {@link Crdt}.
  * @typeParam Self - The interface of the mixin.
  *
  * @return A constructor that creates a mixed type of the input type and the
  * mixin type.
  */
-export type Mixin<Required, Self> = <Input extends Required>(
-  Base: Constructor<Input>
-) => Constructor<Input & Self>;
+export type CrdtMixin<Required extends Crdt, Self> = <Input extends Required>(
+  Base: CrdtConstructor<Input>
+) => CrdtConstructor<Input & Self>;
 
 /**
- * Same as {@link Mixin}, but also takes an optional option of type Option.
+ * Same as a {@link CrdtMixin}, but a mixin of this type can optionally be
+ * configured with an options object of type `Option`.
  */
-export type MixinOpt1<Required, Self, Option1> = <Input extends Required>(
-  Base: Constructor<Input>,
-  option1?: Option1
-) => Constructor<Input & Self>;
+export type CrdtMixinWithOptions<Required extends Crdt, Self, Options> = <
+  Input extends Required
+>(
+  Base: CrdtConstructor<Input>,
+  options?: Options
+) => CrdtConstructor<Input & Self>;


### PR DESCRIPTION
I noticed that the recent mixin changes from #11 had slightly broken the inferred type of the constructors of classes using these mixins: for instance, `crdts.Counter`'s constructor now took a single argument of type `(...args: any[])`.

If a subclass doesn't declare a constructor, we want it to default to a construtor with parameter `(parent: Crdt | CrdtRuntime, id: string, ...otherArgs: any[])`. This PR fixes that; `crdts.Counter` now takes those parameter. It can override them by declaring a new constructor, but it will still need to pass arguments of those types to the `super`.

I also documented the implementation a little better, because it's not trivial.