### PR TITLE
Simplify serialization of maps for protobuf

### DIFF
--- a/client/src/crdts/basic_crdts.ts
+++ b/client/src/crdts/basic_crdts.ts
@@ -167,13 +167,9 @@ export class GCounter
   }
 
   reset() {
-    let pAsIndexSignature: { [key: string]: number } = {};
-    for (let entry of this.state.P.entries()) {
-      pAsIndexSignature[entry[0]] = entry[1];
-    }
-    let message = GCounterMessage.create({
+    const message = GCounterMessage.create({
       reset: {
-        V: pAsIndexSignature,
+        V: Object.fromEntries(this.state.P.entries()),
       },
     });
     super.send(GCounterMessage.encode(message).finish());

--- a/client/src/network/default_causal_broadcast_network.ts
+++ b/client/src/network/default_causal_broadcast_network.ts
@@ -97,14 +97,10 @@ export class myMessage {
    * @returns serialize message
    */
   serialize(): Uint8Array {
-    let vectorMapAsIndexSignature: { [key: string]: number } = {};
-    for (let entry of this.timestamp.vectorMap.entries()) {
-      vectorMapAsIndexSignature[entry[0]] = entry[1];
-    }
-    let message = DefaultCausalBroadcastMessage.create({
+    const message = DefaultCausalBroadcastMessage.create({
       message: this.message,
       sender: this.timestamp.sender,
-      vectorMap: vectorMapAsIndexSignature,
+      vectorMap: Object.fromEntries(this.timestamp.vectorMap.entries()),
     });
     return DefaultCausalBroadcastMessage.encode(message).finish();
   }


### PR DESCRIPTION
A tiny refactoring that simplifies the code that creates maps for protobuf. Low priority, but just a small thing I noticed while working on #60. We can merge later, after deadlines.