### PR TITLE
Doc fixes for yicheng

### DIFF
--- a/crdts/src/list/archiving_mut_list.ts
+++ b/crdts/src/list/archiving_mut_list.ts
@@ -16,14 +16,20 @@ import {
 import { ListPosition } from "./list_position_source";
 
 /**
- * Collab-valued [[CList]] where deletions only "archive"
- * values.
+ * A list of mutable values, each represented by a [[Collab]] of type `C`.
  *
- * Archived values can continue being used on their own
- * and later be restored in the list, unlike in
- * [[DeletingMutCList]]. Note that this comes at the
- * cost of increased memory usage: since deleted values
- * stick around forever, they consume memory forever.
+ * Because the values are Collabs, you can't insert a new value by sending
+ * it over the network directly. Instead, you supply arbitrary InsertArgs
+ * to [[insert]], which sends those values over the network. Then all replicas
+ * construct the actual value - replicas of a new Collab - by calling
+ * the `valueConstructor` callback that you supply in the constructor.
+ * See the constructor's docs for an example.
+ *
+ * When a value is deleted with [[delete]], it is archived and can still
+ * be used, and it can be restored later with [[restore]]. Note this comes
+ * at the cost of increased memory usage: since values are never deleted,
+ * they will occupy memory forever once inserted.
+ * See [[DeletingMutCList]] for an alternative semantics.
  */
 export class ArchivingMutCList<
   C extends Collab,
@@ -37,6 +43,42 @@ export class ArchivingMutCList<
     [ListPosition, InsertArgs]
   >
 > {
+  /**
+   * Constructs an [[ArchivingMutCList]] with the given valueConstructor and
+   * optional arguments.
+   *
+   * The valueConstructor is a callback used to construct newly inserted
+   * values. It takes (arbitrary) InsertArgs, plus an [[InitToken]], and returns
+   * a new value replica. For example, with value type [[CCounter]],
+   * and taking an initial value as
+   * the InsertArgs (`InsertArgs = [initialValue: number]`):
+   * ```
+   * import * as collabs from "@collabs/collabs";
+   * // ...
+   *
+   * function valueConstructor(valueInitToken: collabs.InitToken, initialValue: number) {
+   *   return new collabs.CCounter(valueInitToken, initialValue);
+   * }
+   * // app is a CRDTApp or CRDTContainer
+   * const list = app.registerCollab(
+   *   "list",
+   *   (initToken) => new collabs.ArchivingMutCList(initToken, valueConstructor)
+   * );
+   * ```
+   * Then when any replica calls `list.insert(index, initialValue)`, e.g. in response to
+   * a user button click, all replicas run `valueConstructor` to create
+   * a new counter value. These values are all linked, i.e., they
+   * start with the same value (`initialValue`) and replicate each other's operations.
+   *
+   * For more info, see the [Guide](../../../guide/initialization.html#dynamically-created-collabs).
+   *
+   * @param initToken         [description]
+   * @param valueConstructor  [description]
+   * @param initialValuesArgs = [] Optional, use this to specify InsertArgs for
+   * initial values that are present when the list is created.
+   * @param argsSerializer = DefaultSerializer.getInstance() Optional,
+   * use this to specify a custom [[Serializer]] for InsertArgs.
+   */
   constructor(
     initToken: InitToken,
     valueConstructor: (valueInitToken: InitToken, ...args: InsertArgs) => C,

--- a/crdts/src/list/deleting_mut_list.ts
+++ b/crdts/src/list/deleting_mut_list.ts
@@ -15,6 +15,20 @@ import {
 } from "./movable_mut_list_from_set";
 import { ListPosition } from "./list_position_source";
 
+/**
+ * A list of mutable values, each represented by a [[Collab]] of type `C`.
+ *
+ * Because the values are Collabs, you can't insert a new value by sending
+ * it over the network directly. Instead, you supply arbitrary InsertArgs
+ * to [[insert]], which sends those values over the network. Then all replicas
+ * construct the actual value - replicas of a new Collab - by calling
+ * the `valueConstructor` callback that you supply in the constructor.
+ * See the constructor's docs for an example.
+ *
+ * When a value is deleted with [[delete]], it is deleted permanently and
+ * can no longer be used; future and concurrent operations on that value
+ * are ignored. See [[ArchivingMutCList]] for an alternative semantics.
+ */
 export class DeletingMutCList<
   C extends Collab,
   InsertArgs extends unknown[]
@@ -27,6 +41,42 @@ export class DeletingMutCList<
     [ListPosition, InsertArgs]
   >
 > {
+  /**
+   * Constructs a [[DeletingMutCList]] with the given valueConstructor and
+   * optional arguments.
+   *
+   * The valueConstructor is a callback used to construct newly inserted
+   * values. It takes (arbitrary) InsertArgs, plus an [[InitToken]], and returns
+   * a new value replica. For example, with value type [[CCounter]],
+   * and taking an initial value as
+   * the InsertArgs (`InsertArgs = [initialValue: number]`):
+   * ```
+   * import * as collabs from "@collabs/collabs";
+   * // ...
+   *
+   * function valueConstructor(valueInitToken: collabs.InitToken, initialValue: number) {
+   *   return new collabs.CCounter(valueInitToken, initialValue);
+   * }
+   * // app is a CRDTApp or CRDTContainer
+   * const list = app.registerCollab(
+   *   "list",
+   *   (initToken) => new collabs.DeletingMutCList(initToken, valueConstructor)
+   * );
+   * ```
+   * Then when any replica calls `list.insert(index, initialValue)`, e.g. in response to
+   * a user button click, all replicas run `valueConstructor` to create
+   * a new counter value. These values are all linked, i.e., they
+   * start with the same value (`initialValue`) and replicate each other's operations.
+   *
+   * For more info, see the [Guide](../../../guide/initialization.html#dynamically-created-collabs).
+   *
+   * @param initToken         [description]
+   * @param valueConstructor  [description]
+   * @param initialValuesArgs = [] Optional, use this to specify InsertArgs for
+   * initial values that are present when the list is created.
+   * @param argsSerializer = DefaultSerializer.getInstance() Optional,
+   * use this to specify a custom [[Serializer]] for InsertArgs.
+   */
   constructor(
     initToken: InitToken,
     valueConstructor: (valueInitToken: InitToken, ...args: InsertArgs) => C,

--- a/crdts/src/list/text.ts
+++ b/crdts/src/list/text.ts
@@ -34,7 +34,7 @@ export interface CTextEventsRecord extends CollabEventsRecord {
 
 export class CText
   extends CPrimitive<CTextEventsRecord>
-  implements PositionedList 
+  implements PositionedList
 {
   private readonly positionSource: ListPositionSource<string>;
   /**

--- a/crdts/src/list/text.ts
+++ b/crdts/src/list/text.ts
@@ -34,7 +34,7 @@ export interface CTextEventsRecord extends CollabEventsRecord {
 
 export class CText
   extends CPrimitive<CTextEventsRecord>
-  implements PositionedList
+  implements PositionedList 
 {
   private readonly positionSource: ListPositionSource<string>;
   /**
@@ -57,6 +57,15 @@ export class CText
 
   // OPT: optimize bulk methods.
 
+  /**
+   * Insert the given substring starting at index.
+   *
+   * Existing characters at `>= index` are shifted `values.length`
+   * spots to the right.
+   *
+   * @param index   [description]
+   * @param values  [description]
+   */
   insert(index: number, values: string): void {
     if (values.length === 0) return undefined;
 
@@ -77,6 +86,16 @@ export class CText
     this.sendPrimitive(CTextMessage.encode(message).finish());
   }
 
+  /**
+   * Delete count characters starting at startIndex, i.e., characters
+   * [startIndex, startIndex + count - 1).
+   *
+   * Characters at `>= startIndex + count` are shifted count spots to the
+   * left.
+   *
+   * @param startIndex  [description]
+   * @param count=1     [description]
+   */
   delete(startIndex: number, count = 1): void {
     if (startIndex < 0) {
       throw new Error(`startIndex out of bounds: ${startIndex}`);
@@ -192,6 +211,9 @@ export class CText
     return this.positionSource.length;
   }
 
+  /**
+   * @return the text as an ordinary string
+   */
   toString(): string {
     let ans = "";
     for (const item of this.positionSource.items()) {

--- a/crdts/src/set/archiving_mut_set.ts
+++ b/crdts/src/set/archiving_mut_set.ts
@@ -12,14 +12,20 @@ import { AddWinsCSet } from "./add_wins_set";
 import { DeletingMutCSet } from "./deleting_mut_set";
 
 /**
- * Collab-valued [[CSet]] where deletions only "archive"
- * values.
+ * A set of mutable values, each represented by a [[Collab]] of type `C`.
  *
- * Archived values can continue being used on their own
- * and later be restored in the set, unlike in
- * [[DeletingMutCSet]]. Note that this comes at the
- * cost of increased memory usage: since deleted values
- * stick around forever, they consume memory forever.
+ * Because the values are Collabs, you can't add a new value by sending
+ * it over the network directly. Instead, you supply arbitrary AddArgs
+ * to [[add]], which sends those values over the network. Then all replicas
+ * construct the actual value - replicas of a new Collab - by calling
+ * the `valueConstructor` callback that you supply in the constructor.
+ * See the constructor's docs for an example.
+ *
+ * When a value is deleted with [[delete]], it is archived and can still
+ * be used, and it can be restored later with [[restore]]. Note this comes
+ * at the cost of increased memory usage: since values are never deleted,
+ * they will occupy memory forever once inserted.
+ * See [[DeletingMutCList]] for an alternative semantics.
  */
 export class ArchivingMutCSet<
   C extends Collab,
@@ -32,8 +38,40 @@ export class ArchivingMutCSet<
   private readonly deletedInitialValues: AddWinsCSet<CollabID<C>>;
 
   /**
-   * [constructor description]
-   * @param valueConstructor [description]
+   * Constructs a [[ArchivingMutCSet]] with the given valueConstructor and
+   * optional arguments.
+   *
+   * The valueConstructor is a callback used to construct newly inserted
+   * values. It takes arbitrary AddArgs, plus an [[InitToken]], and returns
+   * a new value replica. For example, with value type [[CCounter]],
+   * and taking an initial value as
+   * the AddArgs (`AddArgs = [initialValue: number]`):
+   * ```
+   * import * as collabs from "@collabs/collabs";
+   * // ...
+   *
+   * function valueConstructor(valueInitToken: collabs.InitToken, initialValue: number) {
+   *   return new collabs.CCounter(valueInitToken, initialValue);
+   * }
+   * // app is a CRDTApp or CRDTContainer
+   * const set = app.registerCollab(
+   *   "set",
+   *   (initToken) => new collabs.ArchivingMutCSet(initToken, valueConstructor)
+   * );
+   * ```
+   * Then when any replica calls `list.add(initialValue)`, e.g. in response to
+   * a user button click, all replicas run `valueConstructor` to create
+   * a new counter value. These values are all linked, i.e., they
+   * start with the same value (`initialValue`) and replicate each other's operations.
+   *
+   * For more info, see the [Guide](../../../guide/initialization.html#dynamically-created-collabs).
+   *
+   * @param initToken         [description]
+   * @param valueConstructor  [description]
+   * @param initialValuesArgs = [] Optional, use this to specify AddArgs for
+   * initial values that are present when the list is created.
+   * @param argsSerializer = DefaultSerializer.getInstance() Optional,
+   * use this to specify a custom [[Serializer]] for InsertArgs.
    */
   constructor(
     initToken: InitToken,

--- a/crdts/src/set/deleting_mut_set.ts
+++ b/crdts/src/set/deleting_mut_set.ts
@@ -32,7 +32,7 @@ import {
  */
 export class DeletingMutCSet<C extends Collab, AddArgs extends unknown[]>
   extends AbstractCSetCollab<C, AddArgs>
-  implements ICollabParent 
+  implements ICollabParent
 {
   private readonly children: Map<string, C> = new Map();
   // constructorArgs are saved for later save calls

--- a/demos/apps/counter/src/app.ts
+++ b/demos/apps/counter/src/app.ts
@@ -8,7 +8,7 @@ import { CRDTContainer } from "@collabs/container";
   // Register Collabs.
   const counter = container.registerCollab(
     "counter",
-    collabs.Pre(collabs.CCounter)()
+    (initToken) => new collabs.CCounter(initToken)
   );
 
   // Refresh the display when the Collabs state changes, possibly

--- a/demos/apps/whiteboard/src/whiteboard.ts
+++ b/demos/apps/whiteboard/src/whiteboard.ts
@@ -11,7 +11,8 @@ import $ from "jquery";
   // The value is the color of the stroke.
   const boardState = container.registerCollab(
     "whiteboard",
-    collabs.Pre(collabs.LWWCMap)<[x: number, y: number], string>()
+    (initToken) =>
+      new collabs.LWWCMap<[x: number, y: number], string>(initToken)
   );
 
   await container.load();

--- a/docs/src/guide/gotchas.md
+++ b/docs/src/guide/gotchas.md
@@ -70,7 +70,7 @@ When listening on events from a `Collab` that is created dynamically in a collec
 
 Do not make your own `InitToken`s, unless you are writing a direct `Collab` subclass that manages its own children.
 
-Only use a given `InitToken` once, in the way intended by its creator. E.g., a collection's `valueConstructor` must return the `Collab` created using its `initToken` parameter. Likewise for a [Pre-Collab](../api/collabs/modules.html#Pre); this is automatic if you use the built-in [`Pre`](../api/collabs/modules.html#Pre) function.
+Only use a given `InitToken` once, in the way intended by its creator. E.g., a collection's `valueConstructor` must return the `Collab` created using its `initToken` parameter.
 
 In a `Collab`'s constructor, only use the `InitToken` in your `super` call or to query its `runtime` (e.g., for passing to [DefaultSerializer](../api/collabs/classes/DefaultSerializer.html)'s constructor in a parameter default).
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -55,4 +55,4 @@ We also publish a core subset of Collabs, [@collabs/core](https://www.npmjs.com/
 
 ## Authors
 
-Collabs was created by Matthew Weidner, Heather Miller, Huairui Qi, Maxime Kjaer, Ria Pradeep, Ignacio Maronna, and Benito Geordie at Carnegie Mellon University's Composable Systems Lab.
+Collabs was created by Matthew Weidner, Heather Miller, Huairui Qi, Maxime Kjaer, Ria Pradeep, Ignacio Maronna, Benito Geordie, and Yicheng Zhang at Carnegie Mellon University's Composable Systems Lab.

--- a/docs/src/quick_start.md
+++ b/docs/src/quick_start.md
@@ -19,8 +19,6 @@ In this quick start, you will make a collaborative counter app: a webpage where 
 
 4. Open `src/app.ts`. Replace the file with the TypeScript code below. This code connects the display area and increment button to a Collabs `CCounter`---a collaborative counter.
 
-
-
 ```ts
 import * as collabs from "@collabs/collabs";
 import { CRDTContainer } from "@collabs/container";
@@ -34,7 +32,7 @@ import { CRDTContainer } from "@collabs/container";
   // Register Collabs.
   const counter = container.registerCollab(
     "counter",
-    collabs.Pre(collabs.CCounter)()
+    (initToken) => new collabs.CCounter(initToken)
   );
 
   // Refresh the display when the Collabs state changes, possibly
@@ -62,10 +60,7 @@ import { CRDTContainer } from "@collabs/container";
   // Signal to the container host that we're ready for use.
   container.ready();
 })();
-
-
 ```
-
 
 5. Save both files, then in the terminal (still in the template's root folder), build your app in development mode: `npm run dev`.
 

--- a/docs/src/walkthrough.md
+++ b/docs/src/walkthrough.md
@@ -41,7 +41,7 @@ import { CRDTContainer } from "@collabs/container";
   // Register Collabs.
   const counter = container.registerCollab(
     "counter",
-    collabs.Pre(collabs.CCounter)()
+    (initToken) => new collabs.CCounter(initToken)
   );
 
   // Refresh the display when the Collabs state changes, possibly
@@ -104,23 +104,14 @@ For this simple app, there is just one `Collab`, a `CCounter`.
 ```ts
 const counter = container.registerCollab(
   "counter",
-  collabs.Pre(collabs.CCounter)()
+  (initToken) => new collabs.CCounter(initToken)
 );
 ```
 
 A few things to note here:
 
 - The first argument to `registerCollab` is a _name_ for the `Collab`, used to identify it across different users. This can be arbitrary, but it's easiest to use the same name as the variable used to store the `Collab`. Each call to `registerCollab` must use a unique name.
-- We don't call `CCounter`'s constructor directly. Indeed, that constructor's first argument, of type `InitToken`, is something we don't have (and shouldn't create ourselves). Instead, we call the function `collabs.Pre(collabs.CCounter)` with the rest of `CCounter`'s constructor arguments - in this case, `()`. `registerCollab` then returns the actual constructed `CCounter`.
-  In general, when constructing `Collab`s, you use `Pre` instead of `new` in this way. I.e.:
-  ```ts
-  Pre(class_name)<generic types>(constructor args)
-  ```
-  instead of
-  ```ts
-  new class_name<generic types>(constructor args)
-  ```
-  [Initialization](./guide/initialization.md) goes into more detail later in the guide.
+- We don't call `CCounter`'s constructor directly. Indeed, that constructor's first argument, of type `InitToken`, is something we don't have (and shouldn't create ourselves). Instead, we provide a callback function that gets the `InitToken`, _then_ constructs (and returns) the `CCounter`. `registerCollab` calls this function internally and returns the constructed `CCounter`, which we store in `counter`. [Initialization](./guide/initialization.md) explains the rationale for this pattern later in the guide.
 
 ### 3. Update Display on Events
 


### PR DESCRIPTION
- Get rid of `Pre` in docs and referenced demos, just use a callback instead (will eventually be removed in the whole lib)
- Class and constructor docs for `DeletingMutCSet`, `DeletingMutCList`, and `Archiving` versions, including an example of how to construct and a link to the Initialization guide page.
- Add Yicheng to contributers list