### PR TITLE
Fix CRichText empty load bug

### DIFF
--- a/crdts/src/list/c_value_list.ts
+++ b/crdts/src/list/c_value_list.ts
@@ -299,13 +299,17 @@ export class CValueList<T> extends AbstractList_CObject<T, [T]> {
     if (this.list.inInitialState) {
       // Shortcut: No need to merge, just load the state directly.
       this.list.load(savedState, this.valueArraySerializer);
-      const values = new Array<T>(this.list.length);
-      const positions = new Array<Position>(this.list.length);
-      for (const [i, position, value] of this.list.entries()) {
-        values[i] = value;
-        positions[i] = position;
+      if (this.list.length > 0) {
+        const values = new Array<T>(this.list.length);
+        const positions = new Array<Position>(this.list.length);
+        for (const [i, position, value] of this.list.entries()) {
+          values[i] = value;
+          positions[i] = position;
+        }
+        // It's important that we don't do this when the length is zero:
+        // 0-length Insert events confuse CRichText and possibly others.
+        this.emit("Insert", { index: 0, values, positions, meta });
       }
-      this.emit("Insert", { index: 0, values, positions, meta });
     } else {
       // We need to merge savedState with our existing state.
       const remote = new LocalList<T>(this.positionSource);

--- a/crdts/test/list/c_list.test.ts
+++ b/crdts/test/list/c_list.test.ts
@@ -633,6 +633,11 @@ describe("CList", () => {
       new CListView(bobList, true);
     });
 
+    afterEach(() => {
+      EventView.check(aliceList);
+      EventView.check(bobList);
+    });
+
     describe("ordering", () => {
       // These tests are a subset of the CValueList ordering tests.
       // In theory these aren't exercising anything that CValueList didn't

--- a/crdts/test/list/c_rich_text.test.ts
+++ b/crdts/test/list/c_rich_text.test.ts
@@ -546,6 +546,11 @@ describe("CRichText", () => {
       new CRichTextView(bobText, true);
     });
 
+    afterEach(() => {
+      EventView.check(aliceText);
+      EventView.check(bobText);
+    });
+
     /**
      * Checks that alice and bob's saves give the same richText state
      * when loaded on a new replica.

--- a/crdts/test/list/c_rich_text.test.ts
+++ b/crdts/test/list/c_rich_text.test.ts
@@ -104,6 +104,8 @@ describe("CRichText", () => {
 
       it("initial", () => {
         Traces.initial(source, [["initial", {}]]);
+        // Also try with truly empty state (no setupOp).
+        Traces.initial(source, [], false);
       });
 
       it("singleOp", () => {

--- a/crdts/test/list/c_value_list.test.ts
+++ b/crdts/test/list/c_value_list.test.ts
@@ -495,6 +495,11 @@ describe("CValueList", () => {
       new IListView(bobList, true);
     });
 
+    afterEach(() => {
+      EventView.check(aliceList);
+      EventView.check(bobList);
+    });
+
     it("inserts once", () => {
       const ans = [0];
       aliceList.insert(0, 0);
@@ -687,6 +692,7 @@ describe("CValueList", () => {
         assert.deepStrictEqual(charlieList.slice(), ans);
 
         checkPositions(alice, aliceList);
+        EventView.check(charlieList);
       });
 
       it("at other node going left", () => {

--- a/crdts/test/list/views.ts
+++ b/crdts/test/list/views.ts
@@ -12,31 +12,37 @@ export class IListView<
   constructor(collab: L, autoCheck: boolean) {
     super(collab, autoCheck);
 
-    collab.on("Insert", (e) => {
-      assert.notStrictEqual(e.index, -1);
-      assert.isAbove(e.positions.length, 0);
-      assert.strictEqual(e.positions.length, e.values.length);
-      const elements: [position: Position, value: T][] = [];
-      for (let i = 0; i < e.values.length; i++) {
-        assert(collab.hasPosition(e.positions[i]));
-        elements.push([e.positions[i], e.values[i]]);
-      }
-      this.view.splice(e.index, 0, ...elements);
-    });
+    collab.on(
+      "Insert",
+      this.wrap((e) => {
+        assert.notStrictEqual(e.index, -1);
+        assert.isAbove(e.positions.length, 0);
+        assert.strictEqual(e.positions.length, e.values.length);
+        const elements: [position: Position, value: T][] = [];
+        for (let i = 0; i < e.values.length; i++) {
+          assert(collab.hasPosition(e.positions[i]));
+          elements.push([e.positions[i], e.values[i]]);
+        }
+        this.view.splice(e.index, 0, ...elements);
+      })
+    );
 
-    collab.on("Delete", (e) => {
-      assert.notStrictEqual(e.index, -1);
-      assert.isAbove(e.positions.length, 0);
-      // Check that the deleted values/positions are accurate.
-      assert.strictEqual(e.positions.length, e.values.length);
-      for (let i = 0; i < e.values.length; i++) {
-        const [position, value] = this.view[e.index + i];
-        assert.strictEqual(e.values[i], value);
-        assert.strictEqual(e.positions[i], position);
-        assert.isFalse(collab.hasPosition(e.positions[i]));
-      }
-      this.view.splice(e.index, e.values.length);
-    });
+    collab.on(
+      "Delete",
+      this.wrap((e) => {
+        assert.notStrictEqual(e.index, -1);
+        assert.isAbove(e.positions.length, 0);
+        // Check that the deleted values/positions are accurate.
+        assert.strictEqual(e.positions.length, e.values.length);
+        for (let i = 0; i < e.values.length; i++) {
+          const [position, value] = this.view[e.index + i];
+          assert.strictEqual(e.values[i], value);
+          assert.strictEqual(e.positions[i], position);
+          assert.isFalse(collab.hasPosition(e.positions[i]));
+        }
+        this.view.splice(e.index, e.values.length);
+      })
+    );
   }
 
   checkInstance(): void {
@@ -52,24 +58,27 @@ export class CListView<C extends Collab> extends IListView<C, CList<C, any>> {
     super(collab, autoCheck);
 
     // Also need to listen on Move events.
-    collab.on("Move", (e) => {
-      assert.strictEqual(e.values.length, e.previousPositions.length);
-      for (let i = 0; i < e.values.length; i++) {
-        assert.strictEqual(e.values[i], this.view[e.previousIndex + i][1]);
-        assert.strictEqual(
-          e.previousPositions[i],
-          this.view[e.previousIndex + i][0]
-        );
-      }
+    collab.on(
+      "Move",
+      this.wrap((e) => {
+        assert.strictEqual(e.values.length, e.previousPositions.length);
+        for (let i = 0; i < e.values.length; i++) {
+          assert.strictEqual(e.values[i], this.view[e.previousIndex + i][1]);
+          assert.strictEqual(
+            e.previousPositions[i],
+            this.view[e.previousIndex + i][0]
+          );
+        }
 
-      this.view.splice(e.previousIndex, e.values.length);
-      assert.strictEqual(e.values.length, e.positions.length);
-      const elements: [position: Position, value: C][] = [];
-      for (let i = 0; i < e.values.length; i++) {
-        elements.push([e.positions[i], e.values[i]]);
-      }
-      this.view.splice(e.index, 0, ...elements);
-    });
+        this.view.splice(e.previousIndex, e.values.length);
+        assert.strictEqual(e.values.length, e.positions.length);
+        const elements: [position: Position, value: C][] = [];
+        for (let i = 0; i < e.values.length; i++) {
+          elements.push([e.positions[i], e.values[i]]);
+        }
+        this.view.splice(e.index, 0, ...elements);
+      })
+    );
 
     // We don't check the archive/restore fields on Insert/Delete events,
     // since we don't know the proper values.
@@ -88,53 +97,62 @@ export class CRichTextView<F extends Record<string, any>> extends EventView<
     // our view.
     super(collab, autoCheck, true);
 
-    collab.on("Insert", (e) => {
-      assert.notStrictEqual(e.index, -1);
-      assert.isAbove(e.positions.length, 0);
-      assert.strictEqual(e.positions.length, e.values.length);
-      const elements: [
-        position: Position,
-        value: string,
-        format: Partial<F>
-      ][] = [];
-      for (let i = 0; i < e.values.length; i++) {
-        assert(collab.hasPosition(e.positions[i]));
-        // Make a copy of format, so we can mutate it per-character later.
-        elements.push([e.positions[i], e.values[i], { ...e.format }]);
-      }
-      this.view.splice(e.index, 0, ...elements);
-    });
+    collab.on(
+      "Insert",
+      this.wrap((e) => {
+        assert.notStrictEqual(e.index, -1);
+        assert.isAbove(e.positions.length, 0);
+        assert.strictEqual(e.positions.length, e.values.length);
+        const elements: [
+          position: Position,
+          value: string,
+          format: Partial<F>
+        ][] = [];
+        for (let i = 0; i < e.values.length; i++) {
+          assert(collab.hasPosition(e.positions[i]));
+          // Make a copy of format, so we can mutate it per-character later.
+          elements.push([e.positions[i], e.values[i], { ...e.format }]);
+        }
+        this.view.splice(e.index, 0, ...elements);
+      })
+    );
 
-    collab.on("Delete", (e) => {
-      assert.notStrictEqual(e.index, -1);
-      assert.isAbove(e.positions.length, 0);
-      // Check that the deleted values/positions are accurate.
-      assert.strictEqual(e.positions.length, e.values.length);
-      for (let i = 0; i < e.values.length; i++) {
-        const [position, value] = this.view[e.index + i];
-        assert.strictEqual(e.values[i], value);
-        assert.strictEqual(e.positions[i], position);
-        assert.isFalse(collab.hasPosition(e.positions[i]));
-        // TODO: if we add format to the event, check it here.
-      }
-      this.view.splice(e.index, e.values.length);
-    });
+    collab.on(
+      "Delete",
+      this.wrap((e) => {
+        assert.notStrictEqual(e.index, -1);
+        assert.isAbove(e.positions.length, 0);
+        // Check that the deleted values/positions are accurate.
+        assert.strictEqual(e.positions.length, e.values.length);
+        for (let i = 0; i < e.values.length; i++) {
+          const [position, value] = this.view[e.index + i];
+          assert.strictEqual(e.values[i], value);
+          assert.strictEqual(e.positions[i], position);
+          assert.isFalse(collab.hasPosition(e.positions[i]));
+          // TODO: if we add format to the event, check it here.
+        }
+        this.view.splice(e.index, e.values.length);
+      })
+    );
 
-    collab.on("Format", (e) => {
-      assert.notStrictEqual(e.startIndex, -1);
-      assert.notStrictEqual(e.endIndex, -1);
-      assert(e.startIndex < e.endIndex);
-      for (let i = e.startIndex; i < e.endIndex; i++) {
-        const format = this.view[i][2];
-        // Check that previousValue is accurate.
-        assert.strictEqual(e.previousValue, format[e.key]);
-        // Update the view.
-        if (e.value === undefined) delete format[e.key];
-        else format[e.key] = e.value;
-        // Check that the whole format is accurate.
-        assert.deepStrictEqual(e.format, format);
-      }
-    });
+    collab.on(
+      "Format",
+      this.wrap((e) => {
+        assert.notStrictEqual(e.startIndex, -1);
+        assert.notStrictEqual(e.endIndex, -1);
+        assert(e.startIndex < e.endIndex);
+        for (let i = e.startIndex; i < e.endIndex; i++) {
+          const format = this.view[i][2];
+          // Check that previousValue is accurate.
+          assert.strictEqual(e.previousValue, format[e.key]);
+          // Update the view.
+          if (e.value === undefined) delete format[e.key];
+          else format[e.key] = e.value;
+          // Check that the whole format is accurate.
+          assert.deepStrictEqual(e.format, format);
+        }
+      })
+    );
   }
 
   checkInstance(): void {

--- a/crdts/test/list/views.ts
+++ b/crdts/test/list/views.ts
@@ -14,6 +14,7 @@ export class IListView<
 
     collab.on("Insert", (e) => {
       assert.notStrictEqual(e.index, -1);
+      assert.isAbove(e.positions.length, 0);
       assert.strictEqual(e.positions.length, e.values.length);
       const elements: [position: Position, value: T][] = [];
       for (let i = 0; i < e.values.length; i++) {
@@ -25,6 +26,7 @@ export class IListView<
 
     collab.on("Delete", (e) => {
       assert.notStrictEqual(e.index, -1);
+      assert.isAbove(e.positions.length, 0);
       // Check that the deleted values/positions are accurate.
       assert.strictEqual(e.positions.length, e.values.length);
       for (let i = 0; i < e.values.length; i++) {
@@ -88,6 +90,7 @@ export class CRichTextView<F extends Record<string, any>> extends EventView<
 
     collab.on("Insert", (e) => {
       assert.notStrictEqual(e.index, -1);
+      assert.isAbove(e.positions.length, 0);
       assert.strictEqual(e.positions.length, e.values.length);
       const elements: [
         position: Position,
@@ -104,6 +107,7 @@ export class CRichTextView<F extends Record<string, any>> extends EventView<
 
     collab.on("Delete", (e) => {
       assert.notStrictEqual(e.index, -1);
+      assert.isAbove(e.positions.length, 0);
       // Check that the deleted values/positions are accurate.
       assert.strictEqual(e.positions.length, e.values.length);
       for (let i = 0; i < e.values.length; i++) {

--- a/crdts/test/map/c_lazy_map.test.ts
+++ b/crdts/test/map/c_lazy_map.test.ts
@@ -234,6 +234,11 @@ describe("CLazyMap", () => {
       new IMapView(bobMap, true);
     });
 
+    afterEach(() => {
+      EventView.check(aliceMap);
+      EventView.check(bobMap);
+    });
+
     it("is initially empty", () => {
       assert.deepStrictEqual(new Set(aliceMap.keys()), new Set([]));
       assert.deepStrictEqual(new Set(bobMap.keys()), new Set([]));

--- a/crdts/test/map/views.ts
+++ b/crdts/test/map/views.ts
@@ -8,19 +8,25 @@ export class IMapView<K, V> extends EventView<IMap<K, V, any>> {
   constructor(collab: IMap<K, V, any>, autoCheck: boolean) {
     super(collab, autoCheck);
 
-    collab.on("Set", (e) => {
-      if (e.previousValue.isPresent) {
-        assert.strictEqual(e.previousValue.get(), this.view.get(e.key));
-      } else {
-        assert.isFalse(this.view.has(e.key));
-      }
-      this.view.set(e.key, e.value);
-    });
+    collab.on(
+      "Set",
+      this.wrap((e) => {
+        if (e.previousValue.isPresent) {
+          assert.strictEqual(e.previousValue.get(), this.view.get(e.key));
+        } else {
+          assert.isFalse(this.view.has(e.key));
+        }
+        this.view.set(e.key, e.value);
+      })
+    );
 
-    collab.on("Delete", (e) => {
-      assert.strictEqual(e.value, this.view.get(e.key));
-      this.view.delete(e.key);
-    });
+    collab.on(
+      "Delete",
+      this.wrap((e) => {
+        assert.strictEqual(e.value, this.view.get(e.key));
+        this.view.delete(e.key);
+      })
+    );
   }
 
   checkInstance(): void {

--- a/crdts/test/number/views.ts
+++ b/crdts/test/number/views.ts
@@ -11,10 +11,13 @@ export class CCounterView extends EventView<CCounter> {
     // Initial value
     this.view = collab.value;
 
-    collab.on("Add", (e) => {
-      assert.strictEqual(e.added, e.value - this.view);
-      this.view = e.value;
-    });
+    collab.on(
+      "Add",
+      this.wrap((e) => {
+        assert.strictEqual(e.added, e.value - this.view);
+        this.view = e.value;
+      })
+    );
   }
 
   checkInstance(): void {

--- a/crdts/test/set/c_set.test.ts
+++ b/crdts/test/set/c_set.test.ts
@@ -2,6 +2,7 @@ import { Collab, CollabID, InitToken, Optional } from "@collabs/core";
 import { assert } from "chai";
 import seedrandom from "seedrandom";
 import { CCounter, CRuntime, CSet, CVar, TestingRuntimes } from "../../src";
+import { EventView } from "../event_view";
 import { Source, Traces } from "../traces";
 import { ISetView } from "./views";
 
@@ -261,6 +262,11 @@ describe("CSet", () => {
 
       new ISetView(aliceSource, true);
       new ISetView(bobSource, true);
+    });
+
+    afterEach(() => {
+      EventView.check(aliceSource);
+      EventView.check(bobSource);
     });
 
     it("returns new Collab", () => {

--- a/crdts/test/set/views.ts
+++ b/crdts/test/set/views.ts
@@ -8,15 +8,21 @@ export class ISetView<T> extends EventView<ISet<T, any>> {
   constructor(collab: ISet<T, any>, autoCheck: boolean) {
     super(collab, autoCheck);
 
-    collab.on("Add", (e) => {
-      assert.isFalse(this.view.has(e.value));
-      this.view.add(e.value);
-    });
+    collab.on(
+      "Add",
+      this.wrap((e) => {
+        assert.isFalse(this.view.has(e.value));
+        this.view.add(e.value);
+      })
+    );
 
-    collab.on("Delete", (e) => {
-      assert(this.view.has(e.value));
-      this.view.delete(e.value);
-    });
+    collab.on(
+      "Delete",
+      this.wrap((e) => {
+        assert(this.view.has(e.value));
+        this.view.delete(e.value);
+      })
+    );
   }
 
   checkInstance(): void {

--- a/crdts/test/traces.ts
+++ b/crdts/test/traces.ts
@@ -77,11 +77,15 @@ export class Traces {
   /**
    * Check the initial value.
    */
-  static initial<C extends Collab, V>(source: Source<C, V>, valueInit: V) {
+  static initial<C extends Collab, V>(
+    source: Source<C, V>,
+    valueInit: V,
+    doSetupOp = true
+  ) {
     const manager = new Manager(source);
 
     // Basics
-    const [alice] = manager.setup(1, true);
+    const [alice] = manager.setup(1, doSetupOp);
     manager.check(alice, valueInit);
 
     this.crossSave(manager, [alice], valueInit);

--- a/crdts/test/var/views.ts
+++ b/crdts/test/var/views.ts
@@ -11,10 +11,13 @@ export class IVarView<T> extends EventView<IVar<T, any>> {
     // Initial value
     this.view = collab.value;
 
-    collab.on("Set", (e) => {
-      assert.strictEqual(e.previousValue, this.view);
-      this.view = e.value;
-    });
+    collab.on(
+      "Set",
+      this.wrap((e) => {
+        assert.strictEqual(e.previousValue, this.view);
+        this.view = e.value;
+      })
+    );
   }
 
   checkInstance(): void {


### PR DESCRIPTION
`CRichText` would print an unhandled error if loaded with an empty state. This was due to `CValueList` emitting a 0-length Insert event if loaded with an empty state, which should not happen.

This change fixes the bug and adds unit tests to catch it.