### PR TITLE
Network opts & fixes

### DIFF
--- a/collabs/src/index.ts
+++ b/collabs/src/index.ts
@@ -77,6 +77,7 @@ export {
   CValueMap,
   CValueSet,
   CVar,
+  ChangeEvent,
   CounterAddEvent,
   CounterEventsRecord,
   DocEventsRecord,

--- a/crdts/src/runtime/c_runtime.ts
+++ b/crdts/src/runtime/c_runtime.ts
@@ -193,7 +193,7 @@ export interface DocEventsRecord {
   /**
    * Emitted after applying a synchronous set of updates. This
    * is a good time to rerender the GUI.
-   * 
+   *
    * When delivering remote updates, you can reduce the number of Change
    * events using [[AbstractDoc.batchRemoteUpdates]]/[[CRuntime.batchRemoteUpdates]].
    */
@@ -351,9 +351,14 @@ export class CRuntime
   }
 
   private beginTransaction() {
-    // For now, we allow local ops when inBatchDeliveries = true,
-    // in case you react to remote updates with your own.
-    // (However, local ops are not allowed inside an actual receive/load call).
+    if (this.inBatchRemote) {
+      throw new Error(
+        "Cannot perform local updates during a remote batch (receive/load)"
+      );
+      // That could confuse event listeners who accumulate events during a
+      // remote batch, then apply them all sequentially at the end (on "Change"):
+      // accumulated events would need to be "transformed" against the local ops.
+    }
 
     this.inTransaction = true;
     // Wait to set meta until we actually send a message, if we do.

--- a/crdts/src/runtime/c_runtime.ts
+++ b/crdts/src/runtime/c_runtime.ts
@@ -193,6 +193,9 @@ export interface DocEventsRecord {
   /**
    * Emitted after applying a synchronous set of updates. This
    * is a good time to rerender the GUI.
+   * 
+   * When delivering remote updates, you can reduce the number of Change
+   * events using [[AbstractDoc.batchRemoteUpdates]]/[[CRuntime.batchRemoteUpdates]].
    */
   Change: ChangeEvent;
 }

--- a/crdts/src/runtime/c_runtime.ts
+++ b/crdts/src/runtime/c_runtime.ts
@@ -92,7 +92,7 @@ export interface MessageEvent {
    */
   senderCounter: number;
   /**
-   * Whether the message is for a local transaction, i.e., it results
+   * Whether the update is from a local transaction, i.e., it results
    * from calling Collab methods on this replica.
    */
   isLocalOp: boolean;
@@ -148,7 +148,7 @@ export interface SavedStateEvent {
    */
   redundant: Map<string, number>;
   /**
-   * Whether the message is for a local transaction, i.e., it results
+   * Whether the update is from a local transaction, i.e., it results
    * from calling Collab methods on this replica.
    */
   isLocalOp: false;
@@ -159,6 +159,18 @@ export interface SavedStateEvent {
  * after applying an update.
  */
 export type UpdateEvent = MessageEvent | SavedStateEvent;
+
+/**
+ * Event emitted by [[CRuntime]]/[[AbstractDoc]]
+ * after applying a synchronous set of updates.
+ */
+export interface ChangeEvent {
+  /**
+   * Whether the change is from a local transaction, i.e., it results
+   * from calling Collab methods on this replica.
+   */
+  isLocalOp: boolean;
+}
 
 /**
  * Events record for a
@@ -182,7 +194,7 @@ export interface DocEventsRecord {
    * Emitted after applying a synchronous set of updates. This
    * is a good time to rerender the GUI.
    */
-  Change: object;
+  Change: ChangeEvent;
 }
 
 /**
@@ -371,7 +383,7 @@ export class CRuntime
       senderCounter: crdtMeta.senderCounter,
       isLocalOp: true,
     });
-    this.emit("Change", {});
+    this.emit("Change", { isLocalOp: true });
   }
 
   /**
@@ -523,7 +535,7 @@ export class CRuntime
     } finally {
       this.inApplyUpdate = false;
     }
-    if (changed) this.emit("Change", {});
+    if (changed) this.emit("Change", { isLocalOp: false });
   }
 
   /**
@@ -662,7 +674,7 @@ export class CRuntime
     } finally {
       this.inApplyUpdate = false;
     }
-    if (changed) this.emit("Change", {});
+    if (changed) this.emit("Change", { isLocalOp: false });
   }
 
   /**

--- a/crdts/src/runtime/c_runtime.ts
+++ b/crdts/src/runtime/c_runtime.ts
@@ -351,14 +351,9 @@ export class CRuntime
   }
 
   private beginTransaction() {
-    if (this.inBatchRemote) {
-      throw new Error(
-        "Cannot perform local updates during a remote batch (receive/load)"
-      );
-      // That could confuse event listeners who accumulate events during a
-      // remote batch, then apply them all sequentially at the end (on "Change"):
-      // accumulated events would need to be "transformed" against the local ops.
-    }
+    // We don't ban local ops during batchRemoteUpdates but outside
+    // of a receive/load call (e.g., during the "Change" event handler -
+    // a reasonable place to update CPresence state).
 
     this.inTransaction = true;
     // Wait to set meta until we actually send a message, if we do.

--- a/demos/apps/rich-text/src/main.ts
+++ b/demos/apps/rich-text/src/main.ts
@@ -351,8 +351,8 @@ wsNetwork.on("Disconnect", (e) => {
     wsNetwork.connect();
   }, 2000);
 });
-wsNetwork.subscribe(doc, docID);
-wsNetwork.subscribe(presenceDoc, presenceDocID);
+wsNetwork.subscribe(doc, docID, { batchRemoteMS: 50 });
+wsNetwork.subscribe(presenceDoc, presenceDocID, { batchRemoteMS: 50 });
 
 // In a real app, you would probably also add on-device storage
 // (@collabs/indexeddb or @collabs/local-storage)

--- a/demos/apps/rich-text/src/main.ts
+++ b/demos/apps/rich-text/src/main.ts
@@ -172,9 +172,11 @@ text.on("Format", (e) => {
   if (!e.isLocalOp) {
     // Send the pendingDelta to Quill.
     // We wait until "Change" so this only happens once per batch.
-    // We don't risk interleaving with local updates (which would require
-    // transforming later deltas) because CRuntime doesn't allow local ops
-    // during a batch.
+    // We don't risk interleaving with Quill's updates because batches
+    // are always synchronous, while Quill-driven updates always occur
+    // in a DOM event.
+    // TODO: will need to adjust this strategy if we allow programmatic ops
+    // via CText or Quill manipulation.
     const delta = pendingDelta;
     pendingDelta = new Delta();
     updateContents(delta);

--- a/docs/src/guide/gotchas.md
+++ b/docs/src/guide/gotchas.md
@@ -101,7 +101,7 @@ Do not attempt operations that require [strong consistency](https://en.wikipedia
 
 See also: [CAP theorem](https://en.wikipedia.org/wiki/CAP_theorem).
 
-# Next Steps
+## Next Steps
 
 You've now finished the Guide and learned Collabs's main concepts!
 

--- a/docs/src/quick_start.md
+++ b/docs/src/quick_start.md
@@ -10,6 +10,7 @@ This page has instructions for using the template, a walkthrough of its starter 
 
 ```bash
 git clone https://github.com/composablesys/collabs-template-app.git
+cd collabs-template-app
 ```
 
 2. Install dependencies:

--- a/indexeddb/src/indexed_db_doc_store.ts
+++ b/indexeddb/src/indexed_db_doc_store.ts
@@ -263,13 +263,15 @@ export class IndexedDBDocStore extends EventEmitter<IndexedDBDocStoreEventsRecor
 
     // 3. Load the updates into doc.
 
-    // Load saved states first, to reduce causal buffering of updates.
-    for (const savedState of savedStates) {
-      doc.load(savedState, this);
-    }
-    for (const message of messages) {
-      doc.receive(message, this);
-    }
+    doc.batchRemoteUpdates(() => {
+      // Load saved states first, to reduce causal buffering of updates.
+      for (const savedState of savedStates) {
+        doc.load(savedState, this);
+      }
+      for (const message of messages) {
+        doc.receive(message, this);
+      }
+    });
     this.emit("Load", { doc, docID });
 
     // Do the next part's save() in a separate task to avoid blocking

--- a/local-storage/src/local_storage_doc_store.ts
+++ b/local-storage/src/local_storage_doc_store.ts
@@ -274,13 +274,15 @@ export class LocalStorageDocStore extends EventEmitter<LocalStorageDocStoreEvent
 
       // 3. Load the updates into doc.
 
-      // Load saved states first, to reduce causal buffering of updates.
-      for (const savedState of savedStates) {
-        doc.load(savedState, this);
-      }
-      for (const message of messages) {
-        doc.receive(message, this);
-      }
+      doc.batchRemoteUpdates(() => {
+        // Load saved states first, to reduce causal buffering of updates.
+        for (const savedState of savedStates) {
+          doc.load(savedState, this);
+        }
+        for (const message of messages) {
+          doc.receive(message, this);
+        }
+      });
       this.emit("Load", { doc, docID });
 
       // Do the next part's save() in a separate task to avoid blocking

--- a/react/src/hooks/use_collab.ts
+++ b/react/src/hooks/use_collab.ts
@@ -45,9 +45,6 @@ export function useCollab(collab: Collab): void {
         // by React (all versions).
         // 2. Waiting until the "Change" event would break React <18's batching,
         // since for local ops, the "Change" event is usually async.
-
-        // OPT: Allow providers to batch multiple receive/load calls into a
-        // single "Change" event, to reduce rerenders with React <18.
       }
     });
     return () => {

--- a/ws-client/src/web_socket_network.ts
+++ b/ws-client/src/web_socket_network.ts
@@ -56,8 +56,11 @@ export interface WebSocketNetworkEventsRecord {
 
 interface DocInfo {
   readonly docID: string;
+  readonly batchRemoteMS: number | null;
   /** The WebSocketNetwork.localCounter value of our last sent message. */
   lastSent: number;
+  /** Pending updates, to be applied in the next batch. */
+  nextBatch: Receive[];
   off?: () => void;
   subscribeDenied?: true;
   unsubscribed?: true;
@@ -212,10 +215,17 @@ export class WebSocketNetwork extends EventEmitter<WebSocketNetworkEventsRecord>
    *
    * @param doc The document to subscribe.
    * @param docID An arbitrary string that identifies which updates to use.
+   * @param options.batchRemoteMS If set, remote updates to doc are
+   * delivered at most once every batchRemoteMS, emitting only a single
+   * doc "Change" event. Set this to reduce redundant renders.
    * @throws If `doc` is already subscribed to a docID.
    * @throws If another doc is subscribed to `docID`.
    */
-  subscribe(doc: AbstractDoc | CRuntime, docID: string) {
+  subscribe(
+    doc: AbstractDoc | CRuntime,
+    docID: string,
+    options: { batchRemoteMS?: number } = {}
+  ) {
     if (this.closed) throw new Error("Already closed");
     if (this.subs.has(doc)) {
       throw new Error("doc is already subscribed to a docID");
@@ -224,7 +234,12 @@ export class WebSocketNetwork extends EventEmitter<WebSocketNetworkEventsRecord>
       throw new Error("Unsupported: multiple docs with same docID");
     }
 
-    this.subs.set(doc, { docID, lastSent: 0 });
+    this.subs.set(doc, {
+      docID,
+      lastSent: 0,
+      nextBatch: [],
+      batchRemoteMS: options.batchRemoteMS ?? null,
+    });
     this.docsByID.set(docID, doc);
     this.sendInternal({ subscribe: { docIDs: [docID] } });
 
@@ -370,7 +385,35 @@ export class WebSocketNetwork extends EventEmitter<WebSocketNetworkEventsRecord>
   private onReceive(message: Receive): void {
     const doc = this.docsByID.get(message.docID);
     if (doc === undefined) return;
+    const info = nonNull(this.subs.get(doc));
 
+    if (info.batchRemoteMS === null) this.deliver(doc, message);
+    else {
+      if (info.nextBatch.length === 0) {
+        // Start of a new batch.
+        setTimeout(() => this.deliverBatch(doc, info), info.batchRemoteMS);
+      }
+      info.nextBatch.push(message);
+    }
+  }
+
+  private deliverBatch(doc: Doc, info: DocInfo): void {
+    if (info.unsubscribed) return;
+
+    doc.batchRemoteUpdates(() => {
+      for (const message of info.nextBatch)
+        try {
+          this.deliver(doc, message);
+        } catch (err) {
+          // We display this error but let future messages go through,
+          // to match non-batched behavior.
+          console.error(err);
+        }
+    });
+    info.nextBatch = [];
+  }
+
+  private deliver(doc: Doc, message: Receive): void {
     // Note: we might get this update before the room Welcome.
     // That is fine; if the update causally depends on existing state,
     // doc will buffer it.

--- a/ws-server/README.md
+++ b/ws-server/README.md
@@ -4,7 +4,7 @@ Part of the Collabs library. Main package: [@collabs/collabs](https://www.npmjs.
 
 **@collabs/ws-server** contains [WebSocketNetworkServer](https://collabs.readthedocs.io/en/latest/api/ws-server/classes/WebSocketNetworkServer.html). It listens to connections from [@collabs/ws-client](https://www.npmjs.com/package/@collabs/ws-client) clients and syncs updates between them. You can also configure it to store updates persistently and to authenticate clients.
 
-This package also provides the `collabs-ws-server` command. It starts a WebSocketNetworkServer on `$PORT` (default: 3001) with in-memory storage and no authentication. This is useful for getting started with a Collabs app; see our [app template](https://github.com/composablesys/collabs-template-app) for an example.
+This package also provides the `collabs-ws-server` command. It starts a WebSocketNetworkServer on `$PORT` (default: 3001) and `$HOST` (default: localhost) with in-memory storage and no authentication. This is useful for getting started with a Collabs app; see our [app template](https://github.com/composablesys/collabs-template-app) for an example.
 
 ## Docs
 

--- a/ws-server/bin/collabs-ws-server.js
+++ b/ws-server/bin/collabs-ws-server.js
@@ -6,7 +6,7 @@ const {
   WebSocketNetworkServer,
 } = require("../build/commonjs/src/web_socket_network_server");
 
-const hostname = process.env.HOSTNAME || "localhost";
+const host = process.env.HOST || "localhost";
 const port = process.env.PORT || 3001;
 
 const server = http.createServer((req, res) => {
@@ -18,6 +18,6 @@ const server = http.createServer((req, res) => {
 const wss = new WebSocketServer({ server });
 new WebSocketNetworkServer(wss);
 
-server.listen(port, hostname, () => {
-  console.log(`collabs-ws-server running at http://${hostname}:${port}/`);
+server.listen(port, host, () => {
+  console.log(`collabs-ws-server running at http://${host}:${port}/`);
 });

--- a/ws-server/src/in_memory_doc_store.ts
+++ b/ws-server/src/in_memory_doc_store.ts
@@ -1,7 +1,7 @@
 import { ServerDocStore } from "./server_doc_store";
 
 /** How many updates before we consider a checkpoint. */
-const updatesBeforeCheckpoint = 100;
+const updatesBeforeCheckpoint = 500;
 /** The minimum time between checkpoints. */
 const checkpointInterval = 10000;
 

--- a/ws-server/src/in_memory_doc_store.ts
+++ b/ws-server/src/in_memory_doc_store.ts
@@ -69,13 +69,14 @@ export class InMemoryDocStore implements ServerDocStore {
 
     // Do checkpoint request if:
     // - There are at least 100 pending updates in the log.
-    // - It has been at least 10 seconds since the last save request,
+    // - It has been at least 10 seconds since the last checkpoint request,
     // including potential failed or long-latency requests.
     if (info.updates.length >= updatesBeforeCheckpoint) {
       if (
         info.lastCheckpointRequestTime === null ||
         info.lastCheckpointRequestTime + checkpointInterval <= Date.now()
       ) {
+        info.lastCheckpointRequestTime = Date.now();
         // The number of our all-time updates included in savedState + updates.
         const updateCount = info.lastCheckpointCounter + info.updates.length;
         return `${updateCount}`;


### PR DESCRIPTION
- Fix ws-server `InMemoryDocStore` bug that caused too many checkpoint requests
- Add `CRuntime.batchRemoteUpdates` method that lets you avoid unnecessary renders (specifically, change events), and use it in the load/welcome step of network providers
- Add ws-client `batchRemoteMS` option (in subscribe) that batches remote updates
- Use above feature in rich-text demo to deliver Quill updates only once per 50 ms. This is important in large groups, where delivering updates to Quill becomes the bottleneck.
- `collabs-ws-server` command: input HOST instead of HOSTNAME