### PR TITLE
`cp --parents` does not work on macos by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
       #     pkg-manager: yarn
       - run:
           name: Install rsync
-          command: sudo apt update && sudo apt install -y rsync
+          command: sudo apt-get update && sudo apt-get install -y rsync
       - run:
           name: Build project
           command: npm run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,9 @@ jobs:
       # - node/install-packages:
       #     pkg-manager: yarn
       - run:
+          name: Install rsync
+          command: sudo apt update && sudo apt install -y rsync
+      - run:
           name: Build project
           command: npm run build
       - run:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,6 +2,8 @@ version: 2
 
 build:
   os: "ubuntu-20.04"
+  apt_packages:
+    - rsync
   tools:
     # Make sure to keep the python version in sync between here and
     # .circleci/config.yml's docker image version.

--- a/core/package.json
+++ b/core/package.json
@@ -70,7 +70,7 @@
     "build:protobuf:ts": "pbts -o generated/proto_compiled.d.ts generated/proto_compiled.js",
     "build:ts": "npm-run-all build:ts:*",
     "build:ts:tsc": "tsc -p tsconfig.json && tsc -p tsconfig.commonjs.json",
-    "build:ts:copy": "cp generated_esm/proto_compiled.js build/esm/generated/proto_compiled.js && cp --parents src/**/*.d.ts build/commonjs && cp --parents src/**/*.d.ts build/esm",
+    "build:ts:copy": "cp generated_esm/proto_compiled.js build/esm/generated/proto_compiled.js && rsync -R src/**/*.d.ts build/commonjs && rsync -R src/**/*.d.ts build/esm",
     "test": "npm-run-all test:*",
     "test:lint": "eslint --ext .ts,.js .",
     "test:unit": "cross-env TS_NODE_PROJECT='./tsconfig.commonjs.json' mocha",

--- a/crdts/package.json
+++ b/crdts/package.json
@@ -75,7 +75,7 @@
     "build:protobuf:ts": "pbts -o generated/proto_compiled.d.ts generated/proto_compiled.js",
     "build:ts": "npm-run-all build:ts:*",
     "build:ts:tsc": "tsc -p tsconfig.json && tsc -p tsconfig.commonjs.json",
-    "build:ts:copy": "cp generated_esm/proto_compiled.js build/esm/generated/proto_compiled.js && cp --parents src/**/*.d.ts build/commonjs && cp --parents src/**/*.d.ts build/esm",
+    "build:ts:copy": "cp generated_esm/proto_compiled.js build/esm/generated/proto_compiled.js && rsync -R src/**/*.d.ts build/commonjs && rsync -R src/**/*.d.ts build/esm",
     "test": "npm-run-all test:*",
     "test:lint": "eslint --ext .ts,.js .",
     "test:unit": "cross-env TS_NODE_PROJECT='./tsconfig.commonjs.json' TS_NODE_SCOPE=true mocha",


### PR DESCRIPTION
Use `rsync -R` instead of `cp --parents`, since `--parents` is not an option on the built in `cp` of macOS. `rsync -R` seems pretty ubiquitous across all *nix