### PR TITLE
Drop Collabs. prefix for consistency

### DIFF
--- a/docs/src/guide/data_modeling.md
+++ b/docs/src/guide/data_modeling.md
@@ -75,11 +75,11 @@ class CPair<T, U> extends CObject {
     // Setup child Collabs.
     this.firstReg = this.registerCollab(
       "firstReg",
-      (init) => new Collabs.CVar(init, firstInitial)
+      (init) => new CVar(init, firstInitial)
     );
     this.secondReg = this.registerCollab(
       "secondReg",
-      (init) => new Collabs.CVar(init, secondInitial)
+      (init) => new CVar(init, secondInitial)
     );
   }
 


### PR DESCRIPTION
Brings the snippet a little closer to actual code in the template from which it was originally taken.

@mweidner037 